### PR TITLE
Added missing mkdir /mnt/hdd/bitcoin command

### DIFF
--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -76,6 +76,7 @@ We use the Bitcoin daemon, called “bitcoind”, that runs in the background wi
   `$ sudo su - bitcoin`
 
 * We add a symbolic link that points to the external hard disk.  
+  `$ mkdir /mnt/hdd/bitcoin`
   `$ ln -s /mnt/hdd/bitcoin /home/bitcoin/.bitcoin`
 
 * Navigate to the home directory an d check the symbolic link (the target must not be red). The content of this directory will actually be on the external hard disk.  


### PR DESCRIPTION
Symbolic link will be red as the /mnt/hdd/bitcoin directory doesn't exist.  Added required mkdir command.