### PR TITLE
Updates to Electrum Personal Server 0.1.7

### DIFF
--- a/raspibolt_64_electrum.md
+++ b/raspibolt_64_electrum.md
@@ -58,23 +58,23 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
   $ cd electrum-personal-server
   
   # download release
-  $ wget https://github.com/chris-belcher/electrum-personal-server/archive/eps-v0.1.6.tar.gz
-  $ wget https://github.com/chris-belcher/electrum-personal-server/releases/download/eps-v0.1.6/eps-v0.1.6.tar.gz.asc
-  $ wget https://raw.githubusercontent.com/chris-belcher/electrum-personal-server/master/pgp/pubkeys/belcher.asc
+  $ wget https://github.com/chris-belcher/electrum-personal-server/archive/electrum-personal-server-v0.1.7.tar.gz
+  $ wget https://github.com/chris-belcher/electrum-personal-server/releases/download/electrum-personal-server-v0.1.7/electrum-personal-server-v0.1.7.tar.gz.asc
+  $ wget https://raw.githubusercontent.com/chris-belcher/electrum-personal-server/master/docs/pubkeys/belcher.asc
   
   # verify that the release is signed by Chris Belcher (check the fingerprint)
   $ gpg --import belcher.asc
-  $ gpg --verify eps-v0.1.6.tar.gz.asc
+  $ gpg --verify electrum-personal-server-v0.1.7.tar.gz.asc
   > gpg: Good signature from "Chris Belcher <false@email.com>" [unknown]
   > Primary key fingerprint: 0A8B 038F 5E10 CC27 89BF  CFFF EF73 4EA6 77F3 1129
   
-  $ tar -xvf eps-v0.1.6.tar.gz  
+  $ tar -xvf electrum-personal-server-v0.1.7.tar.gz
   $ rm *.gz*
   ```
 
 * Copy and edit configuration template (skip this step when updating)  
   ``` 
-  $ cp electrum-personal-server-eps-v0.1.6/config.cfg_sample config.cfg
+  $ cp electrum-personal-server-electrum-personal-server-v0.1.7/config.ini_sample config.cfg
   $ nano config.cfg
   ```
 
@@ -95,13 +95,13 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
 
 * Install Electrum Personal Server
   ```
-  $ cd electrum-personal-server-eps-v0.1.6/
+  $ cd electrum-personal-server-electrum-personal-server-v0.1.7/
   # Install the wheel package first, which is required
   $ pip3 install wheel
   $ pip3 install --user .
   ```
   
-  ![Install Electrum Personal Server with Python Pip](./images/60_eps_pip_install.png)
+  ![Install Electrum Personal Server with Python Pip](https://user-images.githubusercontent.com/32176650/64073511-9a708b00-cc8e-11e9-891d-9a2051083809.png)
 
 ### First start 
 The Electrum Personal Server scripts are installed in the directory `/home/bitcoin/.local/bin/`. Unfortunately, in Raspbian this directory is not in the system path, so the full path needs to be specified when calling these scripts. Alternatively, just [add this directory to your $PATH environment variable](https://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path), but it's not necessary in this guide.

--- a/raspibolt_64_electrum.md
+++ b/raspibolt_64_electrum.md
@@ -101,7 +101,7 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
   $ pip3 install --user .
   ```
   
-  ![Install Electrum Personal Server with Python Pip](https://user-images.githubusercontent.com/32176650/64073511-9a708b00-cc8e-11e9-891d-9a2051083809.png)
+  ![Install Electrum Personal Server with Python Pip](./images/60_eps_pip_install.png)
 
 ### First start 
 The Electrum Personal Server scripts are installed in the directory `/home/bitcoin/.local/bin/`. Unfortunately, in Raspbian this directory is not in the system path, so the full path needs to be specified when calling these scripts. Alternatively, just [add this directory to your $PATH environment variable](https://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path), but it's not necessary in this guide.


### PR DESCRIPTION
Changes the documentation to install Electrum Personal Server version 0.1.7. Also Chris Belcher's public key has changed location and is reflected with thir PR.

It overrides the image "Install Electrum Personal Server with Python Pip" using a temporary image. Please add image to `images/60_eps_pip_install.png` or change it accordingly. This PR does not update the image found in `images/60_eps_electrum-connect.png`.