### PR TITLE
Grep for "^port=" in bitcoin.conf

### DIFF
--- a/resources/20-raspibolt-welcome
+++ b/resources/20-raspibolt-welcome
@@ -115,7 +115,7 @@ fi
 
 # get public IP address & port
 public_ip=$(curl -s ipinfo.io/ip)
-public_port=$(cat ${bitcoin_dir}/bitcoin.conf 2>/dev/null | grep port= | awk -F"=" '{print $2}')
+public_port=$(cat ${bitcoin_dir}/bitcoin.conf 2>/dev/null | grep ^port= | awk -F"=" '{print $2}')
 if [ "${public_port}" = "" ]; then
   if [ $chain  = "test" ]; then
     public_port=18333


### PR DESCRIPTION
When checking to see what port bitcoind is using in bitcoin.conf, this script currently greps for the port number like so:

```
cat ${bitcoin_dir}/bitcoin.conf 2>/dev/null | grep port= | awk -F"=" '{print $2}'
```

However, this would mean that it would pick up the port number for the `rpcport=` from bitcoin.conf (even if it was commented out), such as:

```
# Listen for RPC connections on this TCP port:
#rpcport=8332
```

As a result, this script would end up checking to see if the node is publicly available by doing `nc -z {ip} 8332`, even if the node was running on port 8333 like normal.

So all I've done is make a tiny edit to the grep to only look for lines that start with `port=` only, which avoids accidentally grabbing the wrong port number from lines like `rpcport=` or even `#port=`:

```
cat ${bitcoin_dir}/bitcoin.conf 2>/dev/null | grep ^port= | awk -F"=" '{print $2}'
```