### PR TITLE
Minor fixes

### DIFF
--- a/raspibolt_10_preparations.md
+++ b/raspibolt_10_preparations.md
@@ -20,25 +20,32 @@ Let's get all the required parts and assemble the Raspberry Pi.
 ---
 
 This guide builds on the easily available and very flexible Raspberry Pi 4.
-This amazing piece of hardware is a tiny computer-on-a-chip, costs about $35 and consumes very little energy.
+This amazing piece of hardware is a tiny computer-on-a-chip, costs about $60 and consumes very little energy.
 
 ## Hardware requirements
 
-It is advisable to get the latest Raspberry Pi for good performance:
+This guide is written for the fastest Raspberry Pi, as it makes a lot of hacks and workarounds obsolete.
+You need
 
 * Raspberry Pi 4, with 4 GB RAM
-* Micro SD card: 8 GB or more, incl. adapter to your regular computer
+* microSD card: 8 GB or more, incl. adapter to your regular computer
 * strong USB power adapter: 5V/3A + USB-C cable
 * external hard disk: 500 GB or more
 * optional: Raspberry Pi case
 
 ![Raspberry Pi](images/10_raspberrypi_hardware.png)
 
-*Raspberry Pi 4: a tiny but quite powerful computer for $50*
-
 To run a Lightning node, the full Bitcoin blockchain must be stored locally, which is ~250 GB and growing.
 You can buy a cheap hard disk enclosure and reuse an old 500 GB hard disk.
 I recommend getting a modern 2.5" SSD that can be powered through the USB connection to the Pi directly, which also speeds up initial sync time significantly.
+
+---
+
+## Other computing platforms
+
+This guide works with most Debian-based Linux distributions, be it on other computing platforms, a real laptop or a virtual machine.
+Only the "Raspberry Pi" part is quite specific, but easily adaptable to other environments.
+Over time, it would be great to describe the differences that need to be considered when using other environments like [Odroid](https://www.hardkernel.com/), [Pine64](https://www.pine64.org/) or [Libre Computer](https://libre.computer/).
 
 ---
 

--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -30,17 +30,17 @@ The node runs headless, that means without keyboard or display, so the operating
 ### Enable Secure Shell
 
 Without keyboard or screen, no direct interaction with the Pi is possible during the initial setup.
-After writing the image to the Micro SD card, create an empty file called “ssh” (without extension) in the main directory of the card.
+After writing the image to the microSD card, create an empty file called “ssh” (without extension) in the main directory of the card.
 This causes the Secure Shell (ssh) to be enabled from the start and we will be able to login remotely.
 
-* Create a file `ssh` in the boot partition of the MicroSD card
+* Create a file `ssh` in the boot partition of the microSD card
 
 ### Prepare Wifi
 
-You can run it with a wireless network connection.
+You can run your RaspiBolt over Wifi.
 To avoid using a network cable for the initial setup, you can pre-configure the wireless settings:
 
-* Create a file `wpa_supplicant.conf` on the MicroSD card with the following content.
+* Create a file `wpa_supplicant.conf` on the microSD card with the following content.
   Note that the network name (ssid) and password need to be in double-quotes (like `psk="password"`)
 
   ```
@@ -269,7 +269,7 @@ The external hard disk is then attached to the file system and can be accessed a
   $ ssh admin@raspibolt.local
   ```
 
-* To change system configuration and files that don't belong to the "admin", you have to prefix command with `sudo`.
+* To change system configuration and files that don't belong to the "admin", you have to prefix commands with `sudo`.
   You will be prompted to enter your admin password from time to time for increased security.
 
 ### Make sure USB3 is performant

--- a/raspibolt_21_security.md
+++ b/raspibolt_21_security.md
@@ -61,7 +61,7 @@ $ exit
 ## fail2ban
 
 The SSH login to the Pi must be especially protected.
-The firewall blocks all login attempts from outside your network, but additional steps should be taken to prevent an attacker - maybe from inside your network - to just try out all possible passwords.
+Additional steps should be taken to prevent an attacker to just try out all possible passwords.
 
 The first measure is to install “fail2ban”, a service that cuts off any system with five failed login attempts for ten minutes.
 This makes a brute-force attack unfeasible, as it would simply take too long.
@@ -137,12 +137,14 @@ Follow this guide [Configure “No Password SSH Keys Authentication” with PuTT
   $ sudo nano /etc/ssh/sshd_config
   ```
 
-* Exit and log in again. You can no longer log in with "pi" or "bitcoin", only "admin" has the necessary SSH keys.
+* Restart the SSH daemon, then exit and log in again.
 
   ```sh
   $ sudo systemctl restart sshd
   $ exit
   ```
+
+  You can no longer log in with "pi" or "bitcoin", only "admin" has the necessary SSH keys.
 
 <script id="asciicast-tm3A2UmR65pc63rHSAmHl2eHZ" src="https://asciinema.org/a/tm3A2UmR65pc63rHSAmHl2eHZ.js" async></script>
 
@@ -165,21 +167,17 @@ root soft nofile 128000
 root hard nofile 128000
 ```
 
-![Edit pam.d/limits.conf](images/20_nofile_limits.png){:target="_blank"}
-
 ```sh
 $ sudo nano /etc/pam.d/common-session
 session required pam_limits.so
 ```
-
-![Edit pam.d/common-session](images/20_nofile_common-session.png){:target="_blank"}
 
 ```sh
 $ sudo nano /etc/pam.d/common-session-noninteractive
 session required pam_limits.so
 ```
 
-![Edit pam.d/common-session-noninteractive](images/20_nofile_common-session-noninteractive.png){:target="_blank"}
+<script id="asciicast-ZWxK6wLjrRs1AAnEJpXfIoyPb" src="https://asciinema.org/a/ZWxK6wLjrRs1AAnEJpXfIoyPb.js" async></script>
 
 ---
 

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -28,7 +28,7 @@ After validation, the client can check all future transactions whether they are 
 
 The validated blocks are also the base layer for other applications, like Electrs (to use with hardware wallets) or LND (the Lightning Network client).
 
-Be already warned that the dowloading and validation of all transactions since 2009, more than 600'000 blocks with a size of over 250 GB, is not an easy task.
+Be already warned that the downloading and validation of all transactions since 2009, more than 600'000 blocks with a size of over 250 GB, is not an easy task.
 It's great that the Raspberry Pi 4 can do it, even if it takes a few days, as this was simply not possible with the Raspberry Pi 3.
 
 ---

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -71,7 +71,7 @@ This is a precaution to make sure that this is an official release and not a mal
 
   ```sh
   $ tar -xvf bitcoin-0.19.0.1-arm-linux-gnueabihf.tar.gz
-  $ sudo install -m 0755 -o root -g root -t /usr/bin bitcoin-0.19.0.1/bin/*
+  $ sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-0.19.0.1/bin/*
   $ bitcoind --version
   > Bitcoin Core version v0.19.0.1
   ```
@@ -186,10 +186,10 @@ We use “systemd“, a daemon that controls the startup process using configura
   # Service execution
   ###################
 
-  ExecStart=/usr/bin/bitcoind -daemon \
-                              -pid=/run/bitcoind/bitcoind.pid \
-                              -conf=/mnt/ext/bitcoin/bitcoin.conf \
-                              -datadir=/mnt/ext/bitcoin
+  ExecStart=/usr/local/bin/bitcoind -daemon \
+                                    -pid=/run/bitcoind/bitcoind.pid \
+                                    -conf=/mnt/ext/bitcoin/bitcoin.conf \
+                                    -datadir=/mnt/ext/bitcoin
 
 
   # Process management

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -23,7 +23,7 @@ We set up LND, the Lightning Network Daemon by [Lightning Labs](http://lightning
 
 The installation of LND is straight-forward, but the application is quite powerful and capable of things not explained here. Check out their [Github repository](https://github.com/lightningnetwork/lnd/blob/master/README.md){:target="_blank"} for a wealth of information about their open-source project and Lightning in general.
 
-### Dowload
+### Download
 
 Download and install LND
 

--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -98,7 +98,7 @@ The whole process takes about 30 minutes.
   $ cargo build --release
 
   # install
-  $ sudo cp ./target/release/electrs /usr/bin/
+  $ sudo cp ./target/release/electrs /usr/local/bin/
   ```
 
 <script id="asciicast-PyEVzc5P0i4QX8mVu4zyKicgx" src="https://asciinema.org/a/PyEVzc5P0i4QX8mVu4zyKicgx.js" async></script>
@@ -236,7 +236,7 @@ Electrs need to start automatically on system boot.
   # Service execution
   ###################
 
-  ExecStart=/usr/bin/electrs --conf /mnt/ext/electrs/electrs.conf
+  ExecStart=/usr/local/bin/electrs --conf /mnt/ext/electrs/electrs.conf
 
 
   # Process management

--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -113,7 +113,7 @@ The whole process takes about 30 minutes.
   ln -s /mnt/ext/electrs /home/bitcoin/.electrs
   ```
 
-* Create confitg file
+* Create config file
 
   ```sh
   $ nano /mnt/ext/electrs/electrs.conf
@@ -214,7 +214,7 @@ The whole process takes about 30 minutes.
 
 ### Autostart on boot
 
-Electrs need to start automatically on system boot.
+Electrs needs to start automatically on system boot.
 
 * As user "admin", create the Electrs systemd unit and copy/paste the following configuration. Save and exit.
 
@@ -304,7 +304,7 @@ Electrs need to start automatically on system boot.
 
 ## Secure communication
 
-We should only communicatie with Electrs over an encrypted channel.
+We should only communicate with Electrs over an encrypted channel.
 This is what SSL/TLS (Transport Layer Security) is for.
 Electrs does not handle TLS communication itself, so we use NGINX as a reverse proxy for that.
 
@@ -365,7 +365,7 @@ This means that NGINX provides secure communication to the outside and routes it
 * Test the NGINX configuration and restart the service.
 
   ```sh
-  $ nginx -t
+  $ sudo nginx -t
   $ sudo systemctl restart nginx
   ```
 
@@ -392,7 +392,6 @@ Note that the remote device needs to have Tor installed.
   ```
 
 * Restart Tor and get your connection address.
-  You can even display it as a qr code.
 
   ```sh
   $ sudo systemctl restart tor

--- a/raspibolt_60_bonus.md
+++ b/raspibolt_60_bonus.md
@@ -106,7 +106,7 @@ Control your Lightning node from a different computer within you network, eg. fr
 
 Difficulty: easy
 
-In case your SD card gets corrupted or you brick your node, it's handy to have a quick recovery image at hand. It's not a full backup solution, but allows a system recovery.
+In case your microSD card gets corrupted or you brick your node, it's handy to have a quick recovery image at hand. It's not a full backup solution, but allows a system recovery.
 
 ## [Additional scripts: show balance & channels](raspibolt_67_additional-scripts.md)
 

--- a/raspibolt_65_system-recovery.md
+++ b/raspibolt_65_system-recovery.md
@@ -9,7 +9,7 @@ has_toc: false
 
 *Difficulty: easy*
 
-In case your SD card gets corrupted or you brick your node, it's handy to have a quick recovery image at hand so you can quickly flash the SD card to a previous state. It's not a full backup solution, but allows a system recovery.
+In case your microSD card gets corrupted or you brick your node, it's handy to have a quick recovery image at hand so you can quickly flash the microSD card to a previous state. It's not a full backup solution, but allows a system recovery.
 
 ### Backup essential files on external hard disk
 
@@ -25,19 +25,19 @@ $ tar cvf backup_hdd/lnd.tar .lnd/lnd.conf
 $ exit
 ```
 
-### Create SD card image
+### Create microSD card image
 
 * Shut down your RaspiBolt
   `$ sudo shutdown now`
-* Remove the SD card and connect it to your regular computer
+* Remove the microSD card and connect it to your regular computer
 * Follow this guide to create a disk image:
   https://lifehacker.com/how-to-clone-your-raspberry-pi-sd-card-for-super-easy-r-1261113524
 
 ### System recovery
 
-If you have a spare SD card, you should test the system recovery by writing the disk image to the backup SD card and booting your RaspiBolt with it.
+If you have a spare microSD card, you should test the system recovery by writing the disk image to the backup microSD card and booting your RaspiBolt with it.
 
-If just the SD card was defective, there's no need to restore the files on your external hard disk. In fact it would cause more harm than good. :heavy_check_mark:
+If just the microSD card was defective, there's no need to restore the files on your external hard disk. In fact it would cause more harm than good. :heavy_check_mark:
 
 ---
 

--- a/raspibolt_70_troubleshooting.md
+++ b/raspibolt_70_troubleshooting.md
@@ -56,7 +56,7 @@ Important is that your Raspberry Pi uses the **armv7** CPU architecture.
 
 #### Is you root filesystem read-only?
 
-If you get an error like `unable to ..... : Read-only file system`, this points to a faulty sd card. If linux detects a corrupt root filesystem, it drops into read-only mode. Try to flash the sd card again, or use a different card.
+If you get an error like `unable to ..... : Read-only file system`, this points to a faulty microSD card. If linux detects a corrupt root filesystem, it drops into read-only mode. Try to flash the microSD card again, or use a different card.
 
 #### Is the hard disk mounted?
 


### PR DESCRIPTION
**Consistent usage of /usr/local/bin**
While `/usr/bin` is for distribution-managed user programs, `/usr/local/bin` is for user programs that are not managed by the package manager. All manually installed binaries like `bitcoind`, `lnd` and `electrs` should be in `/usr/local/bin.`

* updates installation instructions
* adjusts systemd unit files

**Wording and consistency**
Small typos, inconsistencies and other nits I stumbled upon proof reading.