### PR TITLE
Correct electrum rpc address setting in electrs config

### DIFF
--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -132,7 +132,7 @@ The whole process takes about 30 minutes.
   daemon_rpc_addr = "127.0.0.1:8332"
 
   # Electrs settings
-  electrum-rpc-addr = "127.0.0.1:50001"
+  electrum_rpc_addr = "127.0.0.1:50001"
   db_dir = "/mnt/ext/electrs/db"
   txid_limit = 1000
 


### PR DESCRIPTION
Typo in config: using dash (command line style) instead of underscore (config style)