### PR TITLE
Bind bitcoind to localhost

### DIFF
--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -120,6 +120,7 @@ server=1
 listen=1
 listenonion=1
 proxy=127.0.0.1:9050
+bind=127.0.0.1
 
 # Connections
 rpcuser=raspibolt


### PR DESCRIPTION
related to https://github.com/Stadicus/RaspiBolt/issues/515

To force bitcoind to not accept clearnet connections, even when
initiated from the outside (e.g. other bitcoin nodes remembering
the clearnet ip address), `bind=127.0.0.1` is added to
`bitcoin.conf`