### PR TITLE
fix: update wpa_supplicant.conf

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -44,9 +44,9 @@ To avoid using a network cable for the initial setup, you can pre-configure the 
   Note that the network name (ssid) and password need to be in double-quotes (like `psk="password"`)
 
   ```
-  country=[COUNTRY_CODE]
-  ctrl_interface=/var/run/wpa_supplicant GROUP=netdev
+  ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
   update_config=1
+  country=[COUNTRY_CODE]
   network={
     ssid="[WIFI_SSID]"
     psk="[WIFI_PASSWORD]"


### PR DESCRIPTION
This is a fix to #455.

Updates wpa_supplicant.conf according to the specification found here, just above "Unsecured Networks" heading:

https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md