### PR TITLE
Update raspibolt_10_preparations.md

### DIFF
--- a/raspibolt_10_preparations.md
+++ b/raspibolt_10_preparations.md
@@ -64,7 +64,7 @@ They should be unique and very secure, at least 12 characters in length. Do **no
 ![xkcd: Password Strength](images/20_xkcd_password_strength.png)
 
 If you need inspiration for creating your passwords: the [xkcd: Password Strength](https://xkcd.com/936/) comic is funny and contains a lot of truth.
-Store a copy of your passwords somewhere safe (preferably in a password manager like [KeePass](https://keepass.info/)) and keep your original notes out of sight once your system is up and running.
+Store a copy of your passwords somewhere safe (preferably in an open source password manager like [KeePassXC](https://keepassxc.org/)) and keep your original notes out of sight once your system is up and running.
 
 ---
 Next: [Raspberry Pi >>](raspibolt_20_pi.md)


### PR DESCRIPTION
Suggest KeepassXC in favor of Keepass.  KeepassXC (https://keepassxc.org) updates are frequent on their github (https://github.com/keepassxreboot/keepassxc).