### PR TITLE
Replace usermod with adduser

### DIFF
--- a/raspibolt_22_privacy.md
+++ b/raspibolt_22_privacy.md
@@ -85,7 +85,7 @@ Log in your RaspiBolt via SSH as user "admin".
   ```sh
   $ cat /etc/group | grep debian-tor
   > debian-tor:x:114:
-  $ sudo usermod -a -G debian-tor bitcoin
+  $ sudo adduser bitcoin debian-tor
   $ cat /etc/group | grep debian-tor
   > debian-tor:x:114:bitcoin
   ```

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -278,7 +278,7 @@ After rebooting, the bitcoind should start and begin to sync and validate the Bi
 * See bitcoind in action by monitoring its log file (exit with `Ctrl-C`)
 
   ```sh
-  $ sudo tail -f /mnt/ext/bitcoin/debug.log
+  $ tail -f /mnt/ext/bitcoin/debug.log
   ```
 
 * Use the Bitcoin Core client `bitcoin-cli` to get information about the current blockchain

--- a/raspibolt_69_tor.md
+++ b/raspibolt_69_tor.md
@@ -82,7 +82,7 @@ For additional reference, the original instructions are available on the [Tor pr
   ```
   $ cat /etc/group | grep debian-tor
   debian-tor:x:113:
-  $ sudo usermod -a -G debian-tor bitcoin
+  $ sudo adduser bitcoin debian-tor
   $ cat /etc/group | grep debian-tor
   debian-tor:x:123:bitcoin
   ```


### PR DESCRIPTION
Hi,

I suggest to replace `usermod` with `adduser` to add users to groups, since `adduser` is more user friendly and it is already used in other places (e.g. `raspibolt_20_pi.md`).