### PR TITLE
Use conf syntax highlighting

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -43,7 +43,7 @@ To avoid using a network cable for the initial setup, you can pre-configure the 
 * Create a file `wpa_supplicant.conf` in the boot partition of the microSD card with the following content.
   Note that the network name (ssid) and password need to be in double-quotes (like `psk="password"`)
 
-  ```
+  ```conf
   ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
   update_config=1
   country=[COUNTRY_CODE]
@@ -489,7 +489,7 @@ Therefore, we will move it to the external drive.
   $ sudo nano /etc/dphys-swapfile
   ```
 
-   ```
+   ```ini
    CONF_SWAPFILE=/mnt/ext/swapfile
 
    # comment or delete the CONF_SWAPSIZE line. It will then be created dynamically

--- a/raspibolt_22_privacy.md
+++ b/raspibolt_22_privacy.md
@@ -96,7 +96,7 @@ Log in your RaspiBolt via SSH as user "admin".
   $ sudo nano /etc/tor/torrc
   ```
 
-  ```
+  ```conf
   # uncomment:
   ControlPort 9051
   CookieAuthentication 1

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -109,7 +109,7 @@ Still as user "bitcoin", open it with Nano and paste the configuration below. Sa
 $ nano /mnt/ext/bitcoin/bitcoin.conf
 ```
 
-```
+```ini
 # RaspiBolt: bitcoind configuration
 # /mnt/ext/bitcoin/bitcoin.conf
 
@@ -174,7 +174,7 @@ We use “systemd“, a daemon that controls the startup process using configura
   $ sudo nano /etc/systemd/system/bitcoind.service
   ```
 
-  ```
+  ```ini
   # RaspiBolt: systemd unit for bitcoind
   # /etc/systemd/system/bitcoind.service
 
@@ -330,7 +330,7 @@ A bigger cache speeds up the initial block download, now we want to reduce memor
   $ sudo nano /mnt/ext/bitcoin/bitcoin.conf
   ```
 
-  ```sh
+  ```ini
   #dbcache=2000
   ```
 

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -78,7 +78,7 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   $ nano /mnt/ext/lnd/lnd.conf
   ```
 
-  ```
+  ```ini
   # RaspiBolt: lnd configuration
   # /mnt/ext/lnd/lnd.conf
 
@@ -220,7 +220,7 @@ Now, let's set up LND to start automatically on system startup.
   $ sudo nano /etc/systemd/system/lnd.service
   ```
 
-  ```
+  ```ini
   # RaspiBolt: systemd unit for lnd
   # /etc/systemd/system/lnd.service
 

--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -119,7 +119,7 @@ The whole process takes about 30 minutes.
   $ nano /mnt/ext/electrs/electrs.conf
   ```
 
-  ```toml
+  ```ini
   # RaspiBolt: electrs configuration
   # /mnt/ext/electrs/electrs.conf
 
@@ -222,7 +222,7 @@ Electrs needs to start automatically on system boot.
   $ sudo nano /etc/systemd/system/electrs.service
   ```
 
-  ```console
+  ```ini
   # RaspiBolt: systemd unit for electrs
   # /etc/systemd/system/electrs.service
 
@@ -383,7 +383,7 @@ Note that the remote device needs to have Tor installed.
   $ sudo nano /etc/tor/torrc
   ```
 
-  ```
+  ```conf
   ############### This section is just for location-hidden services ###
 
   HiddenServiceDir /var/lib/tor/hidden_service_electrs/

--- a/raspibolt_61_system-overview.md
+++ b/raspibolt_61_system-overview.md
@@ -15,7 +15,7 @@ To get a quick overview over the system status, I created [a shell script](resou
 
 This script will run as root, so please check it before blindly trusting me.
 
-```
+```sh
 $ sudo apt install jq net-tools
 $ cd /home/admin/download/
 $ wget https://raw.githubusercontent.com/Stadicus/RaspiBolt/master/resources/20-raspibolt-welcome
@@ -33,7 +33,7 @@ $ sudo ln -s /etc/update-motd.d/20-raspibolt-welcome /usr/local/bin/raspibolt
 
 In case the script runs into problems, it could theoretically prevent you from logging in. We therefore disable all motd execution for the "root" user, so you will always be able to login as "root" to disable it.
 
-```
+```sh
 $ sudo su
 $ touch /root/.hushlogin
 $ exit
@@ -42,7 +42,7 @@ $ exit
 You can now start the script with `sudo raspibolt` and it is shown every time you log in.
 
 If the script is showing 'Public Not reachable' but you do have incoming connections and the blockchain is syncing, you might have a router that does not support NAT Loopback. Please check your node at https://bitnodes.earn.com, if it displays your node as available remove the # on lines 128 and 129 and put them before 130 and 131 by editing the file:
-```
+```sh
 $ sudo nano /etc/update-motd.d/20-raspibolt-welcome
 ```
 Both methods work, but the original method does not rely on third party applications and the earn.com method obviously does, but it is better than no working method at all.

--- a/raspibolt_62_commandline.md
+++ b/raspibolt_62_commandline.md
@@ -35,7 +35,7 @@ alias ls='ls -la --color=always'
 ### Bash completion
 As user “admin”, install bash completion scripts for Bitcoin Core and all Lightning projects. You then can complete commands by pressing the Tab key (e.g. bitcoin-cli getblockch [Tab] → bitcoin-cli getblockchaininfo )
 
-```
+```sh
 $ cd /home/admin/download
 $ wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/bitcoin-cli.bash-completion 
 $ wget https://raw.githubusercontent.com/lightningnetwork/lnd/master/contrib/lncli.bash-completion

--- a/raspibolt_64_electrum.md
+++ b/raspibolt_64_electrum.md
@@ -24,13 +24,13 @@ Before using this setup, please familiarize yourself with all components by sett
 ### Preparations
 
 * With user 'admin', make sure Python3 and PIP are installed. Also the 'setuptools' package is required.
-  ```
+  ```sh
   $ sudo apt install -y python3 python3-pip
   $ sudo pip3 install setuptools
   ```
 
 * Configure firewall to allow incoming requests (please check if you need to adjust the subnet mask as [described in original setup](raspibolt_20_pi.md#enabling-the-uncomplicated-firewall))
-  ```
+  ```sh
   $ sudo ufw allow from 192.168.0.0/24 to any port 50002 comment 'allow EPS from local network'
   $ sudo ufw enable
   $ sudo ufw status
@@ -51,7 +51,7 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
 
 * Download, verify and extract the latest release (check the [Releases page](https://github.com/chris-belcher/electrum-personal-server/releases) on Github for the correct links)
 
-  ```
+  ```sh
   # create new directory on external hdd
   $ mkdir /mnt/ext/electrum-personal-server
   $ ln -s /mnt/ext/electrum-personal-server /home/bitcoin/electrum-personal-server
@@ -73,7 +73,7 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
   ```
 
 * Copy and edit configuration template (skip this step when updating)
-  ```
+  ```sh
   $ cp electrum-personal-server-electrum-personal-server-v0.1.7/config.ini_sample config.cfg
   $ nano config.cfg
   ```
@@ -81,20 +81,20 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
   * Add your wallet master public keys or watch-only addresses to the `[master-public-keys]` and `[watch-only-addresses]` sections. Master public keys for an Electrum wallet can be found in the Electrum client menu `Wallet` -> `Information`.
 
   * In `[bitcoin-rpc]`, uncomment and complete the lines.
-    ```
+    ```ini
     rpc_user = raspibolt
     rpc_password = [PASSWORD_B]
     ```
 
   * In `[electrum-server]`, change the listening `host` to `0.0.0.0`, so that you can reach it from a remote computer. The firewall only accepts connections from within the home network, not from the internet.
-    ```
+    ```ini
     host = 0.0.0.0
     ```
 
 * Save and exit
 
 * Install Electrum Personal Server
-  ```
+  ```sh
   $ cd electrum-personal-server-electrum-personal-server-v0.1.7/
   # Install the wheel package first, which is required
   $ pip3 install wheel
@@ -107,22 +107,22 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
 The Electrum Personal Server scripts are installed in the directory `/home/bitcoin/.local/bin/`. Unfortunately, in Raspbian this directory is not in the system path, so the full path needs to be specified when calling these scripts. Alternatively, just [add this directory to your $PATH environment variable](https://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path), but it's not necessary in this guide.
 
   * The first time the server is run it will import all configured addresses as watch-only into the Bitcoin node. This can take up to 10 minutes, after that the program will exit.
-    ```
+    ```sh
     $ /home/bitcoin/.local/bin/electrum-personal-server /home/bitcoin/electrum-personal-server/config.cfg
     ```
 
   * If your wallet has previous transactions, Electrum Personal Server needs to rescan the Bitcoin blockchain to get the historical information. This can take a long time for the whole blockchain, therefore you can set the start date of the scan (it will still take more than 1 hour per year of history).
-    ```
+    ```sh
     $ /home/bitcoin/.local/bin/electrum-personal-server-rescan /home/bitcoin/electrum-personal-server/config.cfg
     ```
 
   * You can monitor the rescan progress in the Bitcoin Core logfile from a second SSH session:
-    ```
+    ```sh
     $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
     ```
 
   * Run Electrum Personal Server again and connect your Electrum wallet from your regular computer.
-    ```
+    ```sh
     $ /home/bitcoin/.local/bin/electrum-personal-server /home/bitcoin/electrum-personal-server/config.cfg
     ```
 
@@ -156,7 +156,7 @@ If everything works as expected, we will now automate the start of Electrum Pers
 * As "admin", set up the systemd unit for automatic start on boot, save and exit
   `$ sudo nano /etc/systemd/system/eps.service`
 
-```
+```ini
 [Unit]
 Description=Electrum Personal Server
 After=bitcoind.service

--- a/raspibolt_66_remote_lncli.md
+++ b/raspibolt_66_remote_lncli.md
@@ -28,7 +28,7 @@ root@RaspiBolt:/home/admin#  exit
 - Add one new line in the [Application Options] section of lnd.conf to allow rpc from more than just the default localhost  
   `admin ~  ฿  sudo nano /home/bitcoin/.lnd/lnd.conf`
 
-```
+```ini
 [Application Options]
 rpclisten=0.0.0.0:10009
 ```


### PR DESCRIPTION
Hi,

Rouge library (a library used by Jekyll for syntax highlighting) has options to highlight config snippets.
I added `conf`, `ini` language specifications for snippets with configurations. Also I added `sh` language specification where it was missed.