### PR TITLE
Set blocksonly=1 to speed up IBD

### DIFF
--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -129,9 +129,12 @@ zmqpubrawblock=tcp://127.0.0.1:28332
 zmqpubrawtx=tcp://127.0.0.1:28333
 
 # Raspberry Pi optimizations
-dbcache=2000
 maxconnections=40
 maxuploadtarget=5000
+
+# Initial block download optimizations
+dbcache=2000
+blocksonly=1
 ```
 
 🚨 **Change the rpcpassword** to your secure `password [B]`.
@@ -321,8 +324,9 @@ If everything is running smoothly, this is the perfect time to familiarize yours
 
 Once Bitcoin Core is fully synced, we can reduce the size of the database cache.
 A bigger cache speeds up the initial block download, now we want to reduce memory consumption to allow LND and Electrs to run in parallel.
+We also now want to enable the node to listent to and relay transactions.
 
-* As user "admin", comment the following line out (add a `#` at the beginning) in the Bitcoin settings file.
+* As user "admin", comment the following lines out (add a `#` at the beginning) in the Bitcoin settings file.
   Bitcoin Core will then just use the default of 300 MB instead of 2 GB.
   Save and exit.
 
@@ -332,6 +336,7 @@ A bigger cache speeds up the initial block download, now we want to reduce memor
 
   ```sh
   #dbcache=2000
+  #blocksonly=1
   ```
 
 * Restart Bitcoin Core for the settings to take effect.


### PR DESCRIPTION
Hi,

Bitcoin Core has an option to disable the node to listen to and relay transaction.
I set it as an optimization for initial block download.