### PR TITLE
Minor updates

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -194,6 +194,33 @@ $ sudo raspi-config
 
 **Important**: if you connected using the hostname `raspberrypi.local`, you now need to use the new hostname (e.g. `raspibolt.local`)
 
+The following two potential error messages are expected:
+
+* After changing the hostname, e.g. to `raspibolt`, a reboot is required to get rid of this error message.
+  It can be safely ignored for now.
+
+  ```
+  sudo: unable to resolve host raspberrypi: Name or service not known
+  ```
+
+* The `raspi-config` automatically sets your location, but does not generate the corresponding `locale` files:
+
+  ```sh
+  perl: warning: Setting locale failed.
+  perl: warning: Please check that your locale settings:
+  ...
+  LC_NUMERIC = "de_CH.UTF-8",
+  ...
+  are supported and installed on your system.
+  ```
+
+  This error is safe to ignore.
+  If you want to get rid of it, note the setting for `LC_NUMERIC` (e.g. `de_CH.UTF-8`), select this locale in the following configuration screen and configure it as default.
+
+  ```sh
+  $ sudo dpkg-reconfigure locales
+  ```
+
 ### Software update
 
 It is important to keep the system up-to-date with security patches and application updates.

--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -273,10 +273,10 @@ This user does not have admin rights and cannot change the system configuration.
   $ sudo adduser admin bitcoin
   ```
 
-* Shut your RaspiBolt down.
+* Restart your RaspiBolt.
 
   ```sh
-  $ sudo shutdown now
+  $ sudo reboot
   ```
 
 <script id="asciicast-8uhMDvDcDNf3cUT6A3FcqN4lo" src="https://asciinema.org/a/8uhMDvDcDNf3cUT6A3FcqN4lo.js" async></script>

--- a/raspibolt_22_privacy.md
+++ b/raspibolt_22_privacy.md
@@ -80,11 +80,9 @@ Log in your RaspiBolt via SSH as user "admin".
   > User debian-tor
   ```
 
-* Check which users belong to the "debian-tor" group. If "bitcoin" is not there, which is most likely the case, you will need to add it and check again.
+* Make sure that user "bitcoin" belongs to the "debian-tor" group.
 
   ```sh
-  $ cat /etc/group | grep debian-tor
-  > debian-tor:x:114:
   $ sudo adduser bitcoin debian-tor
   $ cat /etc/group | grep debian-tor
   > debian-tor:x:114:bitcoin

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -115,6 +115,7 @@ $ nano /mnt/ext/bitcoin/bitcoin.conf
 
 # Bitcoin daemon
 server=1
+txindex=1
 
 # Network
 listen=1
@@ -145,13 +146,13 @@ blocksonly=1
 
 #### Transaction indexing (optional)
 
-Full transaction indexing is usually not necessary for basic usage of your node. However if you wish to install a block explorer like the [BTC RPC Explorer](raspibolt_6B_btc_rpc_explorer.md), or take advantage of the node for some develoment or analytics capabilities, you might consider adding the following line in the `bitcoin.conf` file that enables the full index for all transactions:
+By default the above configuration enables transaction indexing.
+This allows other applications to query Bitcoin Core about any transaction.
+One example that needs this feature is the [BTC RPC Explorer](raspibolt_6B_btc_rpc_explorer.md), your personal blockchain explorer.
 
-```config
-txindex=1
-```
-
-You can enable this later, but that will require that the node reindex all transactions from the start and that could take a while (similar to the initial blockchain download).
+If you know that you don't need this feature, you can delete the line `txindex=1` in the configuration above.
+This results in a faster initial blockchain verification, and saves about 20 GB of storage.
+If in doubt, just leave it as-is, otherwise you might need to enable it later and reindex the whole blockchain again.
 
 ---
 

--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -54,8 +54,8 @@ As there are no binaries available, we will compile the application directly fro
   ```sh
   # download
   $ cd /tmp
-  $ curl https://static.rust-lang.org/dist/rust-1.41.0-armv7-unknown-linux-gnueabihf.tar.gz -o rust.tar.gz
-  $ curl https://static.rust-lang.org/dist/rust-1.41.0-armv7-unknown-linux-gnueabihf.tar.gz.asc -o rust.tar.gz.asc
+  $ curl https://static.rust-lang.org/dist/rust-1.42.0-armv7-unknown-linux-gnueabihf.tar.gz -o rust.tar.gz
+  $ curl https://static.rust-lang.org/dist/rust-1.42.0-armv7-unknown-linux-gnueabihf.tar.gz.asc -o rust.tar.gz.asc
   $ curl https://keybase.io/rust/pgp_keys.asc | gpg --import
 
   # verify
@@ -105,12 +105,20 @@ The whole process takes about 30 minutes.
 
 ### Configuration & indexing
 
+* Add user "electrs"
+
+  ```sh
+  $ sudo adduser electrs
+  $ sudo adduser electrs bitcoin
+  ```
+
 * Create the Electrs data directory on the external drive and link it to the "bitcoin" user home.
 
   ```sh
-  sudo su - bitcoin
-  mkdir /mnt/ext/electrs
-  ln -s /mnt/ext/electrs /home/bitcoin/.electrs
+  $ mkdir /mnt/ext/electrs
+  $ sudo chown -R electrs:bitcoin /mnt/ext/electrs
+  $ sudo su - electrs
+  $ ln -s /mnt/ext/electrs /home/bitcoin/.electrs
   ```
 
 * Create config file

--- a/raspibolt_6B_btc_rpc_explorer.md
+++ b/raspibolt_6B_btc_rpc_explorer.md
@@ -25,7 +25,9 @@ Built with Node.js, express, bootstrap-v4.
 For the BTC RPC Explorer to work, you need your full node to index all transactions.
 Otherwise, the only transactions your full node will store are the ones pertaining to the node's wallets (which you probably are not going to use).
 In order to do that, you need to set the `txindex` parameter in your Bitcoin Core configuration file (`bitcoin.conf`): [Bitcoin node configuration](raspibolt_30_bitcoin.md#transaction-indexing-optional).
+
 After adding the parameter, just restart Bitcoin Core with `sudo systemctl restart bitcoind`.
+
 As reindexing can take more than a day, you can follow the progress using `sudo tail -f /mnt/ext/bitcoin/debug.log`.
 
 #### Install NodeJS


### PR DESCRIPTION
* bitcoind: txindex=1 by default
  With the performance of RPi4, enabling txindex is not a big deal. To support later addition of services like blockexplorer etc, this setting is enabled by default.
  
  Added explanation what it is and how to disable it.

* explain errors after raspi-conf 
  The 'hostname' and 'locale' errors look quite scary, although they are not critical. This is explained, with optional steps to get rid of the 'locale' error.

* minor improvements
  * formatting
  * Pi: reboot instead of shutdown
  * Privacy: streamline adding 'bitcoin' to 'debian-tor' group
  * Electrs: update to Rust 1.41