### PR TITLE
Update raspibolt_72_zeus-over-tor.md

### DIFF
--- a/raspibolt_72_zeus-over-tor.md
+++ b/raspibolt_72_zeus-over-tor.md
@@ -1,25 +1,22 @@
 ---
 layout: default
-title: Zeus App Via Tor
+title: Zeus app Via Tor v3
 parent: Bonus Section
 nav_order: 30
 has_toc: false
 ---
-## Bonus guide: Connect Zeus App Over Tor
+## Bonus guide: Connect Zeus app over Tor v3
 *Difficulty: medium*
 
-Download the Zeus app, APKs available here: https://github.com/ZeusLN/zeus/releases, 
-on F-Droid and Google Play.
 
-Log in to your RaspiBolt through ssh.
+### Create the Hidden Service:
 
-Edit `torrc` with `sudo nano /etc/tor/torrc` and add the following lines (`myandroid` can be unique):
+In your Raspibolt, edit `torrc` with `$ sudo nano /etc/tor/torrc` and add the following lines at the end:
 ```
-HiddenServiceDir /var/lib/tor/lnd_api/
-HiddenServiceVersion 2
-HiddenServiceAuthorizeClient stealth myandroid
+
+HiddenServiceDir /var/lib/tor/lnd_REST/
+HiddenServiceVersion 3
 HiddenServicePort 8080 127.0.0.1:8080
-HiddenServicePort 10009 127.0.0.1:10009
 ```
 Save (Ctrl+O, ENTER) and exit (Ctrl+X)
 
@@ -28,27 +25,16 @@ Restart Tor:
 $ sudo systemctl restart tor
 ```
 
-View the private credentials of your new hidden service. The first part is the onion address, the second part is the secret.
+Generate Tor v3 address
+
 ```
-$ sudo cat /var/lib/tor/lnd_api/hostname
-z1234567890abc.onion AbyZXCfghtG+E0r84y/nR # client: myandroid
+$ sudo cat /var/lib/tor/lnd_REST/hostname
+
+Copy the HIDDEN_SERVICE_ADDRESS.onion
 ```
 
-Download Orbot for Android. https://guardianproject.info/apps/orbot/
 
-Open Orbot. Click the `⋮`, select `hidden services ˃`, select `Client cookies`.
-
-Press the + button on the lower right. Type in the the onion address and secret cookie you revealed with `sudo cat /var/lib/tor/lnd_api/hostname`.  
- Must enter onion address and add .onion to end in address area.  
-For the cookie you need all the information including [cookie] # client : [client]  
-So for example:AbyZXCfghtG+E0r84y/nR # client: myandroid
-
-Go back to Orbot's main screen, and select the gear icon under `tor enabled apps`.  
-Add `Zeus`, then press back.  
-Click `stop` on the big onion logo.  
-Exit orbot and reopen it. Turn on `VPN Mode`.  
-Start your connection to the Tor network by clicking on the big onion (if it has not automatically connected already)
-
+### Install lndconnect:
 
 On your Raspibolt, make sure Go is installed (should be v1.11 or higher):  
 ```
@@ -57,8 +43,8 @@ $ go version
 If need to install Go, run these:
 
 ```
-$ wget https://storage.googleapis.com/golang/go1.11.linux-armv6l.tar.gz
-$ sudo tar -C /usr/local -xzf go1.11.linux-armv6l.tar.gz
+$ wget https://storage.googleapis.com/golang/go1.13.linux-armv6l.tar.gz
+$ sudo tar -C /usr/local -xzf go1.13.linux-armv6l.tar.gz
 $ sudo rm *.gz
 $ sudo mkdir /usr/local/gocode
 $ sudo chmod 777 /usr/local/gocode
@@ -71,15 +57,56 @@ $ export PATH=$PATH:$GOPATH/bin
 Install [lndconnect](https://github.com/LN-Zap/lndconnect):
 ```
 $ cd ~/download
-$ wget https://github.com/LN-Zap/lndconnect/releases/download/v0.1.0/lndconnect-linux-armv7-v0.1.0.tar.gz
-$ sudo tar -xvf lndconnect-linux-armv7-v0.1.0.tar.gz --strip=1 -C /usr/local/bin
+$ wget https://github.com/LN-Zap/lndconnect/releases/download/v0.2.0/lndconnect-linux-armv7-v0.2.0.tar.gz
+$ sudo tar -xvf lndconnect-linux-armv7-v0.2.0.tar.gz --strip=1 -C /usr/local/bin
 ```
-Switch to user `bitcoin` and generate the LND connect URI QR code:  
-It will be a big QR code so maximize your terminal window and use CTRL - to shrink the code further to fit the screen.
-Replace the `host` variable with the onion address previously generated.
+
+
+### Generate the lndconnect QR code:
+
+Switch to user `bitcoin` and generate the QR code.
+
+Paste the `HIDDEN_SERVICE_ADDRESS.onion` previously coppied.
 
 ```
 $ sudo su bitcoin
-$ lndconnect --lnddir=/home/bitcoin/.lnd --host=z1234567890abc.onion --port=8080
+$ lndconnect --host=HIDDEN_SERVICE_ADDRESS.onion --port=8080
 ```
-Scan it with Zeus and you are done.
+It will be a big QR code so maximize your terminal window and use CTRL - to shrink the code further to fit the screen.
+
+If using Putty, you can select a smaller font size: Category -> Window -> Apearance -> Font settings -> Change -> Size.
+
+
+### Install Zeus app on Android device:
+
+Download the [Zeus](https://zeusln.app/) app, available on:
+
+* [GitHub](https://github.com/ZeusLN/zeus/releases), 
+* [F-Droid](https://f-droid.org/en/packages/com.zeusln.zeus/) 
+* [Google Play](https://play.google.com/store/apps/details?id=com.zeusln.zeus)
+
+
+### Set up Orbot in the Android device:
+
+Download Orbot for Android. https://guardianproject.info/apps/orbot/
+
+On Orbot's main screen select the gear icon under `tor enabled apps`.
+
+Add `Zeus`, then press back.
+
+Click `stop` on the big onion logo.
+
+Exit Orbot and reopen it. Turn on `VPN Mode`.
+
+Start your connection to the Tor network by clicking on the big onion (if it has not automatically connected already).
+
+If Orbot is misbehaving try stopping other VPN services on the phone and/or restart.
+
+
+### Connect Zeus app to you LN node over Tor v3:
+
+To open Zeus click on it's icon at the Tor_Enabled-Apps in Orbot.
+
+In Zeus app, select the gear icon and press ´Add a new node´.
+
+Scan the ´lndconnect QR code´ and you are done.


### PR DESCRIPTION
Hello, connection with Tor v3 is much easier, as you do not need Client Cookies for Orbot.

Followed Openoms guide and adapted it to Raspibolt II, https://github.com/openoms/bitcoin-tutorials/blob/master/Zap_to_RaspiBlitz_through_Tor.md

Thanks!

