### PR TITLE
Replacing apt upgrade with apt full-upgrade, fixing locale error and notice Bitnode not connectable

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -220,6 +220,16 @@ The following two potential error messages are expected:
   ```sh
   $ sudo dpkg-reconfigure locales
   ```
+  If the above fix does not remove the locale error, it is probably your host machine that you use to SSH from pushing its locale onto the Pi. What you need to do is very simple: make Pi stop accepting locale over SSH regardless of origin. You do that by editing sshd_config file in nano editor:
+
+```sh
+  $ sudo nano /etc/ssh/sshd_config
+  ```
+All you need to do now is find the AcceptEnv LANG LC_* and make sure to comment it out so it looks like this:
+```sh
+  #AcceptEnv LANG LC_*
+  ```
+Now CTRL+X (save) and exit, and the error will be gone.
 
 ### Software update
 

--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -230,7 +230,7 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 
 ```sh
 $ sudo apt update
-$ sudo apt upgrade
+$ sudo apt full-upgrade
 ```
 
 Make sure that all necessary software packages are installed:

--- a/raspibolt_69_tor.md
+++ b/raspibolt_69_tor.md
@@ -162,6 +162,7 @@ Bitcoin Core is starting and we now need to check if all connections are truly r
   * Go to [bitnodes.earn.com](https://bitnodes.earn.com/) and copy/paste your `.onion` address here:
   ![bitnodes](./images/69_bitnodes.png)
   * Check directly using the API by using this link (insert your own .onion address, like https://bitnodes.earn.com/nodes/627jdioviypreq7v.onion-8333/):
+  * If you dont see it as connectable, it does not mean that everything is not OK. Bitnode's site in combination with your new node sometimes takes some time to show properly. Try it again in few hours (or tomorrow).
     ```
     https://bitnodes.earn.com/nodes/[your-onion-adress.onion]-8333/
     ```


### PR DESCRIPTION
sudo apt full-upgrade should be better due to the fact that it should install new packages if necessary to satisfy dependencies of upgrading already installed packages.