### PR TITLE
1st option to stop bitcoind should be bitcoin-cli stop instead of ctrl+c

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -220,6 +220,16 @@ The following two potential error messages are expected:
   ```sh
   $ sudo dpkg-reconfigure locales
   ```
+  If the above fix does not remove the locale error, it is probably your host machine that you use to SSH from pushing its locale onto the Pi. What you need to do is very simple: make Pi stop accepting locale over SSH regardless of origin. You do that by editing sshd_config file in nano editor:
+
+```sh
+  $ sudo nano /etc/ssh/sshd_config
+  ```
+All you need to do now is find the AcceptEnv LANG LC_* and make sure to comment it out so it looks like this:
+```sh
+  #AcceptEnv LANG LC_*
+  ```
+Now CTRL+X (save) and exit, and the error will be gone.
 
 ### Software update
 

--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -230,7 +230,7 @@ The “Advanced Packaging Tool” (apt) makes this easy.
 
 ```sh
 $ sudo apt update
-$ sudo apt upgrade
+$ sudo apt full-upgrade
 ```
 
 Make sure that all necessary software packages are installed:

--- a/raspibolt_30_bitcoin.md
+++ b/raspibolt_30_bitcoin.md
@@ -163,12 +163,28 @@ If in doubt, just leave it as-is, otherwise you might need to enable it later an
 ## Running bitcoind
 
 Still logged in as user "bitcoin", let's start "bitcoind" manually.
-Monitor the log file a few minutes to see if it works fine (it may stop at "dnsseed thread exit", that's ok).
-Exit the logfile monitoring with `Ctrl-C`, check the blockchain info and, if there are no errors, stop "bitcoind" again.
 
 ```sh
 $ bitcoind
 ```
+Monitor the output for few minutes to see if it works fine (it may stop at "dnsseed thread exit", that's ok).
+
+Now it is time that we stop bitcoind. To safely stop your node, run the following "bitcoin-cli stop" command, in a new terminal SSH window logged in as user "bitcoin. 
+Open new terminal window and initiate new SSH session:
+
+```sh
+$ ssh admin@raspibolt.local or ssh admin@local-Pi-IP
+```
+Now in this window run the following command, while watching what will happen in the session where bitcoind is running:
+
+```sh
+$ bitcoin-cli stop
+```
+After the command is executed, type "exit" to close the second session from where you ran the stop command.
+
+We can also stop it with `Ctrl+C` which will result in stopping the process and proceeding with the shutdown but it is better to practice safe hygine right away in terms of stopping to make sure that database does not get corrupted while stopping and just to get familiar with bitcoin-cli right away, because that is you will be using later on.
+
+🔍 *more: [safely stopping the node](https://bitcoin.org/en/full-node#other-linux-daemon){:target="_blank"} in Bitcoin.org* 
 
 _Note: the following screencast skips longer waiting times, the initial start is longer in real life._
 

--- a/raspibolt_69_tor.md
+++ b/raspibolt_69_tor.md
@@ -162,6 +162,7 @@ Bitcoin Core is starting and we now need to check if all connections are truly r
   * Go to [bitnodes.earn.com](https://bitnodes.earn.com/) and copy/paste your `.onion` address here:
   ![bitnodes](./images/69_bitnodes.png)
   * Check directly using the API by using this link (insert your own .onion address, like https://bitnodes.earn.com/nodes/627jdioviypreq7v.onion-8333/):
+  * If you dont see it as connectable, it does not mean that everything is not OK. Bitnode's site in combination with your new node sometimes takes some time to show properly. Try it again in few hours (or tomorrow).
     ```
     https://bitnodes.earn.com/nodes/[your-onion-adress.onion]-8333/
     ```


### PR DESCRIPTION
Hi,
 
 I made an edit that instruct user to use bitcoin-cli stop for the first time. 
That way they are getting to know the commands that they will be using later on instead of just using ctrl+c for the rest of the node's life.
I left ctrl+c as an alternative passage after bitcoin-cli stop.