### PR TITLE
Update raspibolt_61_system-overview.md to use /tmp

### DIFF
--- a/raspibolt_61_system-overview.md
+++ b/raspibolt_61_system-overview.md
@@ -17,7 +17,7 @@ This script will run as root, so please check it before blindly trusting me.
 
 ```sh
 $ sudo apt install jq net-tools
-$ cd /home/admin/download/
+$ cd /tmp/
 $ wget https://raw.githubusercontent.com/Stadicus/RaspiBolt/master/resources/20-raspibolt-welcome
 
 # check script & exit


### PR DESCRIPTION
The location `/home/admin/download/` isn't guaranteed to exist, but /tmp is. 
Since the script is moved anyways, there's no reason to enforce existence of a download folder.