### PR TITLE
Update raspibolt_40_lnd.md to lnd v0.10.4-beta

### DIFF
--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -29,27 +29,27 @@ Download and install LND
 
 ```sh
 $ cd /tmp
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.3-beta/lnd-linux-armv7-v0.10.3-beta.tar.gz
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.3-beta/manifest-v0.10.3-beta.txt
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.3-beta/manifest-v0.10.3-beta.txt.sig
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.4-beta/lnd-linux-armv7-v0.10.4-beta.tar.gz
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.4-beta/manifest-v0.10.4-beta.txt
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.10.4-beta/manifest-v0.10.4-beta.txt.sig
 $ wget https://keybase.io/roasbeef/pgp_keys.asc
 
-$ sha256sum --check manifest-v0.10.3-beta.txt --ignore-missing
-> lnd-linux-armv7-v0.10.3-beta.tar.gz: OK
+$ sha256sum --check manifest-v0.10.4-beta.txt --ignore-missing
+> lnd-linux-armv7-v0.10.4-beta.tar.gz: OK
 
 $ gpg ./pgp_keys.asc
 > 9769140D255C759B1EB77B46A96387A57CAAE94D
 
 $ gpg --import ./pgp_keys.asc
-$ gpg --verify manifest-v0.10.3-beta.txt.sig
+$ gpg --verify manifest-v0.10.4-beta.txt.sig
 > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
 > Primary key fingerprint: 9769 140D 255C 759B 1EB7  7B46 A963 87A5 7CAA E94D
 >      Subkey fingerprint: 4AB7 F8DA 6FAE BB3B 70B1  F903 BC13 F65E 2DC8 4465
 
-$ tar -xzf lnd-linux-armv7-v0.10.3-beta.tar.gz
-$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.10.3-beta/*
+$ tar -xzf lnd-linux-armv7-v0.10.4-beta.tar.gz
+$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.10.4-beta/*
 $ lnd --version
-> lnd version 0.10.3-beta commit=v0.10.3-beta
+> lnd version 0.10.4-beta commit=v0.10.4-beta
 ```
 
 <script id="asciicast-DvuCHl1ibT4eursipO0Z53xf5" src="https://asciinema.org/a/DvuCHl1ibT4eursipO0Z53xf5.js" async></script>


### PR DESCRIPTION
The v0.10.4-beta release of LND on 2020-07-15 mainly addresses a Windows file handle issue but its best to stay in lockstep with the latest versions.  This will also resolve the System Overview showing the user to "Update!".