### PR TITLE
Rust: add warning for ARM32 binaries

### DIFF
--- a/raspibolt_50_electrs.md
+++ b/raspibolt_50_electrs.md
@@ -51,6 +51,8 @@ As there are no binaries available, we will compile the application directly fro
 
 * Install the Rust programming language
 
+  🚨 This Rust installation is for Linux ARM32 systems only. Don't install the following binaries on other platforms, it could damage your system.
+
   ```sh
   # download
   $ cd /tmp


### PR DESCRIPTION
Adresses this comment from Kixunil:

> Also we had an issue recently that someone installed Rust using your
> guide on x86_64, which broke the system. Perhaps an explicit warning
> that the guide will only work on RPi would be useful?