### PR TITLE
Recommend creating password file BEFORE writing

### DIFF
--- a/raspibolt_6A_auto-unlock.md
+++ b/raspibolt_6A_auto-unlock.md
@@ -18,8 +18,10 @@ This is why a script that automatically unlocks the wallet is  helpful. The pass
 `$ systemd --version`
 
 
-* As user "admin", create a new directory and save your LND wallet password [C] into a text file
-  `$ sudo mkdir /etc/lnd`
+* As user "admin", create a new directory, prepare it and save your LND wallet password [C] into a text file
+  `$ sudo mkdir -m 700 /etc/lnd`
+  `$ sudo chown root:root /etc/lnd`
+  `$ sudo install -o root -g root -m 600 -T /dev/null /etc/lnd/pwd`
   `$ sudo nano /etc/lnd/pwd`
 
 * The following script unlocks the LND wallet through its web service (REST interface). Some additional information:
@@ -29,6 +31,7 @@ This is why a script that automatically unlocks the wallet is  helpful. The pass
   * All automatic unlocks are recorded in `audit.log`.
 
 * Copy the following script it into a new file.
+ `$ sudo install -o root -g root -m 700 -T /dev/null /etc/lnd/unlock`
  `$ sudo nano /etc/lnd/unlock`
 
   ```bash
@@ -59,14 +62,6 @@ This is why a script that automatically unlocks the wallet is  helpful. The pass
 
   echo "$? $(date)" >> /etc/lnd/audit.log
   exit 0
-  ```
-
-* Make the directory and all content accessible only for "root"
-
-  ```bash
-  $ sudo chmod 400 /etc/lnd/pwd
-  $ sudo chmod 100 /etc/lnd/unlock
-  $ sudo chown root:root /etc/lnd/*
   ```
 
 * Edit the LND systemd unit. This starts the script directly after LND is running.


### PR DESCRIPTION
This changes the recommendation to write the password and `chmod` the file afterwards to creating an empty file with correct permissions first and writing the password into it afterwards. This avoids theoretical attack of a malicious app seeing the password between writing it and protecting the file.

Note that this whole exercise, especially setting the owner as root, may be pointless because any process that can access TLS private key or run under the same user as lnd can steal password/sats no matter what kind of unlocking mechanism is used. Protecting lnd in such scenarios is physically impossible. And if you assume these scenarios will not happen, then it makes sense to assume `pwd` file will not be accessed by other user than the one running `lnd`, so in conclusion `pwd` file **may** be owned/accessible by the user running `lnd` without any loss of security. Running the unlocker script under same user may be preferred as it doesn't endanger the rest of the system.

I will suggest to reword the introduction in the followup PR. I felt it's better separating them.