### PR TITLE
Enable Wumbo channels and Anchor channels for LND

### DIFF
--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -97,6 +97,8 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   debuglevel=info
   maxpendingchannels=5
   listen=localhost
+  protocol.anchors=true
+  protocol.wumbo-channels=true
 
   [Bitcoin]
   bitcoin.active=1


### PR DESCRIPTION
Enable Anchor Commitments and Wumbo Channels

See https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf for all lnd.conf options

; If set, lnd will use anchor channels by default if the remote channel party
; supports them. Note that lnd will require 1 UTXO to be reserved for this
; channel type if it is enabled.
; protocol.anchors=true

; If set, then lnd will create and accept requests for channels larger than 0.16
; BTC
; protocol.wumbo-channels=true