### PR TITLE
Update BTC RPC Explorer to v3.1.0

### DIFF
--- a/raspibolt_55_explorer.md
+++ b/raspibolt_55_explorer.md
@@ -87,7 +87,7 @@ We are going to install the BTC RPC Explorer in the home directory since it does
   Since the program is written in JavaScript, there is no need to compile.
 
   ```sh
-  $ git clone --branch v2.0.1 https://github.com/janoside/btc-rpc-explorer.git
+  $ git clone --branch v3.1.0 https://github.com/janoside/btc-rpc-explorer.git
   $ cd btc-rpc-explorer
   $ npm install
   ```
@@ -281,7 +281,7 @@ Updating to a [new release](https://github.com/janoside/btc-rpc-explorer/release
   ```sh
   $ cd ~/btc-rpc-explorer
   $ git fetch
-  $ git checkout v2.0.1
+  $ git checkout v3.1.0
   $ npm install
   $ exit
   ```


### PR DESCRIPTION
This changes documentation for installation and upgrades to use the beautiful 3.x version of BTC RPC Explorer

![Screenshot from 2021-04-17 14-29-58](https://user-images.githubusercontent.com/14304023/115123138-af944d80-9f89-11eb-85fa-199f431d87f2.png)
