### PR TITLE
Update raspibolt_73_static_backup_dropox.md

### DIFF
--- a/raspibolt_73_static_backup_dropox.md
+++ b/raspibolt_73_static_backup_dropox.md
@@ -13,45 +13,33 @@ This guide explains one way to automatically upload the channels.backup file on 
 The following scripts were created by [Vindard](https://github.com/vindard)
 
 #### *Risk : Minimal* 
-The channels.backup file is encrypted so that it is safe to transmit over the Internet and to store on (e.g.) a cloud server.
+The channel.backup file is encrypted so that it is safe to transmit over the Internet and to store on (e.g.) a cloud server.
 
 #### *Requirements: lnd version higher than 0.6*
-
-
 
 ### Setup Dropbox API Key
     
 In your web browser, do the following:
 
 1. Go to https://www.dropbox.com/developers/apps/create and sign in
-
-1. Choose **Dropbox Api**
-
-    ![Dropbox API 1](https://raw.githubusercontent.com/vindard/lnd-backup/master/images/dropbox-1.png)
-
-1. Choose **App Folder**
-
-    ![Dropbox API 2](https://raw.githubusercontent.com/vindard/lnd-backup/master/images/dropbox-2.png)
-
-1. Name your app and click **Create App** to proceed
-
-    ![Dropbox API 3](https://raw.githubusercontent.com/vindard/lnd-backup/master/images/dropbox-3.png)
-
-1. On the settings page for your new app, scroll down to **OAuth 2** and click **Generate**
-
-    ![Dropbox API 4](https://raw.githubusercontent.com/vindard/lnd-backup/master/images/dropbox-4.png)
-
-1. You will now see a string of letters and numbers appear. This is your **Api Token**. Copy this token and keep it safe for the next steps. This api token will be referenced as `<dropbox-api-token>` in the next step.
-
+2. For section 1 (_Choose an API_), select **Scoped access NEW**
+3. For section 2 (_Choose the type of access you need_), select **App Folder**
+4. For section 3 (_Name your app_), name your app and click **Create App** to proceed<br/>![Dropbox API 1](https://i.postimg.cc/7hSqGFmL/pic1.jpg)
+5. Go to the **Permission** tab, and in the **Files and folders** section, select **files.metadata.write**, **files.content.write** and **files.content.read**
+6. Click the **Submit** button in the pop-up window at the bottom of the screen.<br/>![Dropbox API 1](https://i.postimg.cc/fRQkWKWC/pic2.jpg)
+7. Go back to the **Settings** tab, scroll down to **OAuth 2**
+8. For **Access token expiration**, select **No expiration**
+9. Click **Generate**<br/>![Dropbox API 1](https://i.postimg.cc/xdJ6nn6B/pic3.jpg)
+10. You will now see a string of letters, numbers and special characters appear. This is your **Api Token**. Copy this token and keep it safe for the next steps. This api token will be referenced as `<dropbox-api-token>` in the next step.
 
 ### Preparation on the RaspiBolt
 As user "admin", download the script, make it executable and move to the global bin folder.
 
 ```bash
-$ cd /home/admin/download/
+$ cd /tmp/
 $ wget https://gist.githubusercontent.com/vindard/e0cd3d41bb403a823f3b5002488e3f90/raw/4bcf3c0163f77443a6f7c00caae0750b1fa0d63d/lnd-channel-backup.sh
 
-# check script & modify with your <dropbox-api-token> (third line)
+# check script & modify with your <dropbox-api-token> (third line, place the token string inside the double quotes)
 $ sudo nano lnd-channel-backup.sh
 
 $ sudo chmod +x lnd-channel-backup.sh
@@ -83,7 +71,7 @@ Start
 
 Monitor
 
-`$ journalctl -fu backup-channels`
+`$ sudo journalctl -fu backup-channels`
 
 Run at boot
 


### PR DESCRIPTION
1. Corrected typo channels.backup to channel.backup
2. The Dropbox app creation webpage has changed since the guide has created. I updated the section (both instructions and pictures) to match the new layout and options of the webpage.
    Note 1: The pictures are hosted on https://postimages.org/... maybe this is not optimal and a better hosting location and URL could be used?
    Note 2: Dropbox mentions that the no-expiraton token is less secure than the short-lived token and will be deprecated in the future. Is it possible to use the short-lived token for our use case?
3. In the 'Preparation on the Raspibolt, there is no /home/admin/download/ folder so the first command gives an error message. Updated the command to use the /tmp/ folder as is used for the 'System overview' script.
4. Added a note about placing the API token string within  the double quotes to avoid confusion about using them or not.
5. Added a 'sudo' for the journal monitoring command