### PR TITLE
Update raspibolt_40_lnd.md (many updates of the lnd/litd guide)

### DIFF
--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -179,17 +179,16 @@ Enter the following command:
 $ sudo raspi-config
 ```
 
-* First, on `1` change your password to your `password [A]`.
-* Next, choose Update `8` to get the latest configuration tool
-* Network Options `2`:
-  * you can give your node a cute hostname like “raspibolt”
-  * configure your Wifi connection
-* Boot Options `3`:
-  * choose `Desktop / CLI` → `B1 Console` and
-  * `Wait for network at boot`
-* Advanced `7`: run `Expand Filesystem`
-* Exit by selecting `<Finish>`, and `<No>` as no reboot is necessary
+* First, choose `1 System options` (press enter) and navigate to `S3 Password` (down arrow, and press enter) and change your password to your `password [A]`
+* Next, choose `8 Update` to get the latest configuration tool.
+* Next, choose `1 System options` and then `S4 Hostname`. You can give your node a cute hostname like “raspibolt.
+* Next, choose `1 System options` and then `S1 Wireless LAN` and then `B1 Console`.
+* Next, choose `1 System options` and then `S5 Boot/Auto Login` and configure your Wifi connection.
+* Next, choose `1 System options` and then `S6 Network at boot` and select `<Yes>`.
+* Next, choose `6 Advanced options` and then `A1 Expand Filesystem`.
+* Exit by selecting `<Finish>` (right arrow twice), and `<No>` as no reboot is necessary.
 
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-1oSmvJaZLCuN3hUIn33OZCtJy" src="https://asciinema.org/a/1oSmvJaZLCuN3hUIn33OZCtJy.js" async></script>
 
 **Important**: if you connected using the hostname `raspberrypi.local`, you now need to use the new hostname (e.g. `raspibolt.local`)

--- a/raspibolt_20_pi.md
+++ b/raspibolt_20_pi.md
@@ -179,16 +179,17 @@ Enter the following command:
 $ sudo raspi-config
 ```
 
-* First, choose `1 System options` (press enter) and navigate to `S3 Password` (down arrow, and press enter) and change your password to your `password [A]`
-* Next, choose `8 Update` to get the latest configuration tool.
-* Next, choose `1 System options` and then `S4 Hostname`. You can give your node a cute hostname like “raspibolt.
-* Next, choose `1 System options` and then `S1 Wireless LAN` and then `B1 Console`.
-* Next, choose `1 System options` and then `S5 Boot/Auto Login` and configure your Wifi connection.
-* Next, choose `1 System options` and then `S6 Network at boot` and select `<Yes>`.
-* Next, choose `6 Advanced options` and then `A1 Expand Filesystem`.
-* Exit by selecting `<Finish>` (right arrow twice), and `<No>` as no reboot is necessary.
+* First, on `1` change your password to your `password [A]`.
+* Next, choose Update `8` to get the latest configuration tool
+* Network Options `2`:
+  * you can give your node a cute hostname like “raspibolt”
+  * configure your Wifi connection
+* Boot Options `3`:
+  * choose `Desktop / CLI` → `B1 Console` and
+  * `Wait for network at boot`
+* Advanced `7`: run `Expand Filesystem`
+* Exit by selecting `<Finish>`, and `<No>` as no reboot is necessary
 
-_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-1oSmvJaZLCuN3hUIn33OZCtJy" src="https://asciinema.org/a/1oSmvJaZLCuN3hUIn33OZCtJy.js" async></script>
 
 **Important**: if you connected using the hostname `raspberrypi.local`, you now need to use the new hostname (e.g. `raspibolt.local`)

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -42,6 +42,7 @@ $ gpg ./roasbeef.asc
 > uid Olaoluwa Osuntokun <laolu32@gmail.com>
 
 $ gpg --import ./roasbeef.asc
+$ gpg --verify manifest-roasbeef-v0.13.1-beta.sig manifest-v0.13.1-beta.txt
 >gpg: Signature made Mon 19 Jul 2021 22:41:37 BST
 >gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
 >gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -143,8 +143,8 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   db.bolt.auto-compact=true
   # How long ago the last compaction of a database file must be for it to be
   # considered for auto compaction again. Can be set to 0 to compact on every
-  # startup. (default: 168h)
-  db.bolt.auto-compact-min-age=168
+  # startup. (default: 168h; the time unit must be present, i.e. s, m or h, except for 0)
+  db.bolt.auto-compact-min-age=168h
 
   [Bitcoin]
   bitcoin.active=1
@@ -712,8 +712,8 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   lnd.db.bolt.auto-compact=true
   # How long ago the last compaction of a database file must be for it to be
   # considered for auto compaction again. Can be set to 0 to compact on every
-  # startup. (default: 168h)
-  lnd.db.bolt.auto-compact-min-age=168
+  # startup. (default: 168h; the time unit must be present, i.e. s, m or h, except for 0)
+  lnd.db.bolt.auto-compact-min-age=168h
   
   # [Bitcoin]
   lnd.bitcoin.active=1

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -29,38 +29,34 @@ Download and install LND
 
 ```sh
 $ cd /tmp
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.11.1-beta/lnd-linux-armv7-v0.11.1-beta.tar.gz
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.11.1-beta/manifest-v0.11.1-beta.txt
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.11.1-beta/manifest-v0.11.1-beta.txt.sig
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.11.1-beta/roasbeef-manifest-v0.11.1-beta.txt.sig
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.1-beta/lnd-linux-armv7-v0.13.1-beta.tar.gz
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.1-beta/manifest-v0.13.1-beta.txt
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.13.1-beta/manifest-roasbeef-v0.13.1-beta.sig
 $ wget -O roasbeef.asc https://keybase.io/roasbeef/pgp_keys.asc
-$ wget -O bitconner.asc https://keybase.io/bitconner/pgp_keys.asc
 
-$ sha256sum --check manifest-v0.11.1-beta.txt --ignore-missing
-> lnd-linux-armv7-v0.11.1-beta.tar.gz: OK
+$ sha256sum --check manifest-v0.13.1-beta.txt --ignore-missing
+> lnd-linux-armv7-v0.13.1-beta.tar.gz: OK
 
 $ gpg ./roasbeef.asc
-> 9769140D255C759B1EB77B46A96387A57CAAE94D
-$ gpg ./bitconner.asc
-> 9C8D61868A7C492003B2744EE7D737B67FA592C7
+> pub rsa4096 2019-10-13 [C] E4D85299674B2D31FAA1892E372CBD7633C61696
+> uid Olaoluwa Osuntokun <laolu32@gmail.com>
 
 $ gpg --import ./roasbeef.asc
-$ gpg --import ./bitconner.asc
-$ gpg --verify manifest-v0.11.1-beta.txt.sig
-> gpg: Good signature from "Conner Fromknecht <conner@lightning.engineering>" [unknown]
-> Primary key fingerprint: 9C8D 6186 8A7C 4920 03B2  744E E7D7 37B6 7FA5 92C7
-$ gpg --verify roasbeef-manifest-v0.11.1-beta.txt.sig manifest-v0.11.1-beta.txt
-> gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [expired]
-> gpg: Note: This key has expired!
-> Primary key fingerprint: 9769 140D 255C 759B 1EB7  7B46 A963 87A5 7CAA E94D
->      Subkey fingerprint: 4AB7 F8DA 6FAE BB3B 70B1  F903 BC13 F65E 2DC8 4465
+>gpg: Signature made Mon 19 Jul 2021 22:41:37 BST
+>gpg:                using RSA key 60A1FA7DA5BFF08BDCBBE7903BBD59E99B280306
+>gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
+>gpg: WARNING: This key is not certified with a trusted signature!
+>gpg:          There is no indication that the signature belongs to the owner.
+>Primary key fingerprint: E4D8 5299 674B 2D31 FAA1  892E 372C BD76 33C6 1696
+>     Subkey fingerprint: 60A1 FA7D A5BF F08B DCBB  E790 3BBD 59E9 9B28 0306
 
-$ tar -xzf lnd-linux-armv7-v0.11.1-beta.tar.gz
-$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.11.1-beta/*
+$ tar -xzf lnd-linux-armv7-v0.13.1-beta.tar.gz
+$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.13.1-beta/*
 $ lnd --version
-> lnd version 0.11.1-beta commit=v0.11.1-beta
+> lnd version 0.13.1 commit=v0.13.1-beta
 ```
 
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-DvuCHl1ibT4eursipO0Z53xf5" src="https://asciinema.org/a/DvuCHl1ibT4eursipO0Z53xf5.js" async></script>
 
 ### Configuration
@@ -97,8 +93,57 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   debuglevel=info
   maxpendingchannels=5
   listen=localhost
-  protocol.anchors=true
+  
+  # Fee settings - default LND base fee = 1000 (mSat), default LND fee rate = 1 (ppm)
+  bitcoin.basefee=1000
+  bitcoin.feerate=1
+  
+  # Minimum channel size (in satoshis, default is 20,000 sats)
+  minchansize=100000
+  
+  # Accept AMP (multi-paths) payments and wumbo channels
+  accept-amp=true
   protocol.wumbo-channels=true
+  
+  # Save on closing fees
+  ## The target number of blocks in which a cooperative close initiated by a remote peer should be confirmed (default: 10 blocks).
+  coop-close-target-confs=24
+
+  #########################
+  # Improve startup speed # (from https://www.lightningnode.info/advanced-tools/lnd.conf by Openoms)
+  #########################
+  # If true, we'll attempt to garbage collect canceled invoices upon start.
+  gc-canceled-invoices-on-startup=true
+  # If true, we'll delete newly canceled invoices on the fly.
+  gc-canceled-invoices-on-the-fly=true
+  # Avoid historical graph data sync
+  ignore-historical-gossip-filters=1
+  # Enable free list syncing for the default bbolt database. This will decrease
+  # start up time, but can result in performance degradation for very large
+  # databases, and also result in higher memory usage. If "free list corruption"
+  # is detected, then this flag may resolve things.
+  sync-freelist=true
+  # Avoid high startup overhead
+  # If true, will apply a randomized staggering between 0s and 30s when
+  # reconnecting to persistent peers on startup. The first 10 reconnections will be
+  # attempted instantly, regardless of the flag's value
+  stagger-initial-reconnect=true
+
+  ########################
+  # Compact the database # (slightly modified from https://www.lightningnode.info/advanced-tools/lnd.conf by Openoms)
+  ########################
+  # Can be used on demand by commenting in/out the two options below: it can take several minutes
+  [bolt]
+  # Whether the databases used within lnd should automatically be compacted on
+  # every startup (and if the database has the configured minimum age). This is
+  # disabled by default because it requires additional disk space to be available
+  # during the compaction that is freed afterwards. In general compaction leads to
+  # smaller database files.
+  db.bolt.auto-compact=true
+  # How long ago the last compaction of a database file must be for it to be
+  # considered for auto compaction again. Can be set to 0 to compact on every
+  # startup. (default: 168h)
+  db.bolt.auto-compact-min-age=168
 
   [Bitcoin]
   bitcoin.active=1
@@ -113,16 +158,16 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
 
 🔍 *more: [sample-lnd.conf](https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf){:target="_blank"} with all possible options in the LND project repository*
 
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-BIhZQuGGoUKtKDsawTpysYa3o" src="https://asciinema.org/a/BIhZQuGGoUKtKDsawTpysYa3o.js" async></script>
 
 ---
 
 ## Run LND
 
-Again, we switch to the user "bitcoin" and first start LND manually to check if everything works fine.
+Still with user "bitcoin", we first start LND manually to check if everything works fine.
 
 ```sh
-$ sudo su - bitcoin
 $ lnd
 ```
 
@@ -159,7 +204,7 @@ These 24 words, combined with your passphrase (optional `password [D]`)  is all 
   ```sh
   $2 exit
   ```
-
+  
 <script id="asciicast-xv9Gq3G5Pu5A1Jtxu2bACRvjQ" src="https://asciinema.org/a/xv9Gq3G5Pu5A1Jtxu2bACRvjQ.js" async></script>
 
 💡 _In this screencast I use the awesome [`tmux`](https://www.ocf.berkeley.edu/~ckuehl/tmux/){:target="_blank"} to run multiple Terminal sessions in parallel.
@@ -169,7 +214,7 @@ But you can just connect to your RaspiBolt with two separate SSH sessions._
 
 Let's authorize the "admin" user to work with LND using the command line interface `lncli`. For that to work, we need to copy the Transport Layer Security (TLS) certificate and the permission files (macaroons) to the admin home folder.
 
-* Check if the TLS certificates and `admin.macaroon` have been created.
+* Check if the TLS certificates (`tls.cert` and `tls.key`) have been created.
 
   ```sh
   $2 sudo ls -la /mnt/ext/lnd/
@@ -214,6 +259,7 @@ $2 exit
 
 This should terminate LND "gracefully" in SSH session 1 that can now be used interactively again.
 
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-o7YMV8E3KAWyVXq3VdzATImYX" src="https://asciinema.org/a/o7YMV8E3KAWyVXq3VdzATImYX.js" async></script>
 
 ### Autostart on boot
@@ -324,16 +370,16 @@ Once you send real bitcoin to your RaspiBolt, you have "skin in the game".
 
 * Make sure your RaspiBolt is working as expected.
 * Get a little practice with `bitcoin-cli` and its options (see [Bitcoin Core RPC documentation](https://bitcoin-rpc.github.io/){:target="_blank"})
-* Try a few restarts (`sudo reboot`), is everything starting fine?
+* Try a few restarts (first stop lnd and bitcoind with `lncli stop`, `sudo systemctl stop lnd`, `sudo systemctl stop bitcoind` and then reboot with `sudo reboot`), is everything starting fine (don't forget to unlock the wallet after each reboot with `lncli unlock`)?
 
 ### Funding your Lightning node
 
-* Generate a new Bitcoin address to receive funds on-chain and send a small amount of Bitcoin to it from any wallet of your choice.
+* Generate a new Bitcoin address (p2wkh = native SegWit/Bech32) to receive funds on-chain and send a small amount of Bitcoin to it from any wallet of your choice.
   [🕮 `newaddress`](https://api.lightning.community/#newaddress){:target="_blank"}
-
+  
   ```sh
-  $ lncli newaddress np2wkh
-  > "address": "3JqmUWMD9mqmdPhMr4sQ9XV7p4o9Cn62CG"
+  $ lncli newaddress p2wkh
+  > "address": "bc1..."
   ```
 
 * Check your LND wallet balance
@@ -348,48 +394,44 @@ Once you send real bitcoin to your RaspiBolt, you have "skin in the game".
   }
   ```
 
-As soon as your funding transaction is mined, LND will show its amount as "confirmed_balance".
+As soon as your funding transaction is mined (1 confirmation), LND will show its amount as "confirmed_balance".
 
 💡 If you want to open a few channels, you might want to send a few transactions.
 If you have only one [UTXO](https://bitcoin.org/en/glossary/unspent-transaction-output), you need to wait for the change to return to your wallet after every new channel opening.
 
+
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-8tL55NcHD5zdaHlBJkFbFXaxV" src="https://asciinema.org/a/8tL55NcHD5zdaHlBJkFbFXaxV.js" async></script>
 
 ### Opening channels
 
-Although LND features an "autopilot", we manually open some channels.
-I recommend to go on [1ML.com](https://1ml.com){:target="_blank"} and look for a mix of big and small nodes with decent Node Ranks.
+Although LND features an optional "autopilot", we manually open some channels.
+I recommend to go on [Amboss.Space](https://www.amboss.space/){:target="_blank"} or [1ML.com](https://1ml.com){:target="_blank"} and look for a mix of big and small nodes with decent Node Ranks.
 
 To connect to a remote node, you need its URI that looks like `<pubkey>@host`:
 
-* the `<pubkey>` is just a long hexadecimal number, like `03abc8abc44453abc7b5b64b4f7b1abcdefb18e102db0abcde4b9cfe93763abcde`
+* the `<pubkey>` is just a long hexadecimal number, like `03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f`
 * the `host` can be a domain name, an ip address or a Tor onion address, followed by the port number (usually `:9735`)
 
-Just grab the whole URI above the big QR code and use it as follows:
+Just grab the whole URI above the big QR code and use it as follows (we will use the ACINQ node as an example):
 
 * **Connect** to the remote node, with the full URI.
   [🕮 `connect`](https://api.lightning.community/#connectpeer){:target="_blank"}
 
   ```sh
-  $ lncli connect 03abc8abc44453abc7b5b64b4f7b1abcdefb18e102db0abcde4b9cfe93763abcde@112.33.44.123:9735
+  $ lncli connect 03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f@34.239.230.56:9735
   ```
 
 * **Open a channel** using the `<pubkey>` and the channel capacity in satoshis.
   [🕮 `openchannel`](https://api.lightning.community/#openchannel){:target="_blank"}
 
   One Bitcoin equals 100 million satoshis, so at $10'000/BTC, $10 amount to 0.001 BTC or 100'000 satoshis.
-  To avoid mistakes, you can just use an [online converter](https://www.buybitcoinworldwide.com/satoshi/btc-to-satoshi).
+  To avoid mistakes, you can just use an [online converter](https://www.buybitcoinworldwide.com/satoshi/to-usd/).
 
-  This will open a channel with fees using the built in estimator 
+  The command as a built-in fee estimator, but to avoid overpaying fees, you can manually control the fees for the funding transaction by using the `sat_per_byte` argument as follows (to select the appropriate fee, in sats/vB, check [mempool.space](https://mempool.space/){:target="_blank"}) 
   ```sh
-  $ lncli openchannel 03abc8abc44453abc7b5b64b4f7b1abcdefb18e102db0abcde4b9cfe93763abcde 100000 0
+  $ lncli openchannel --sat_per_vbyte 8 03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f 100000 0
   ```
-  
-  You can manually control the fees for the funding transaction by using the `sat_per_byte` argument as follows
-  ```sh
-  $ lncli openchannel --sat_per_byte 8 03abc8abc44453abc7b5b64b4f7b1abcdefb18e102db0abcde4b9cfe93763abcde 100000 0
-  ```
-  
 
 * **Check your funds**, both in the on-chain wallet and the channel balances.
   [🕮 `walletbalance`](https://api.lightning.community/#walletbalance){:target="_blank"}
@@ -419,6 +461,7 @@ Just grab the whole URI above the big QR code and use it as follows:
     * lncli payinvoice lnbc10n1pw......................gsj59
     ```
 
+_(Warning: the video below is outdated and does not correspond exactly to the commands above)_
 <script id="asciicast-ATudEzl9xUe7wlodVQuVuuUL6" src="https://asciinema.org/a/ATudEzl9xUe7wlodVQuVuuUL6.js" async></script>
 
 ### More commands
@@ -477,7 +520,14 @@ A quick reference with common commands to play around with:
   ```sh
   $ lncli payinvoice [INVOICE]
   ```
+  
+* Send a payment to a node without invoice using AMP (both sender and receiver nodes have to have AMP enabled):
+  [􀀁 `sendpayment`](https://api.lightning.community/#sendpayment){:target="_blank"}
 
+  ```sh
+  $ lncli sendpayment --amp --fee_limit 1 --dest=<node_pubkey> --final_cltv_delta=144 --amt=<amount_in_sats> 
+  ```
+  
 * Check the payments that you sent:
   [🕮 `listpayments`](https://api.lightning.community/#listpayments){:target="_blank"}
 
@@ -504,7 +554,7 @@ A quick reference with common commands to play around with:
 
   ```sh
   $ lncli listchannels
-  $ lncli closechannel [FUNDING_TXID] [OUTPUT_INDEX]
+  $ lncli closechannel --sat_per_vbyte <fee> [FUNDING_TXID] [OUTPUT_INDEX]
   ```
 
 * to force close a channel (if your peer is offline or not cooperative), use `--force`
@@ -531,6 +581,10 @@ LiT is a software suite of Lightning Labs which contains LND, Faraday (accountin
 Because Pool is alpha software, LiT is alpha software too. The LND part is however in beta and the behavior is exactly the same as LND.
 
 You cannot run LiT and LND at the same time.
+
+The Lightning Terminal UI requires a password. Select a new password:
+
+`[ E ] Master user password`
 
 ### Download LiT
 
@@ -580,7 +634,7 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   ```sh
   $ mkdir /home/bitcoin/.lit
   ```
-* Create the LiT configuration file and paste the following content (adjust to your alias). Save and exit.
+* Create the LiT configuration file and paste the following content (adjust to your alias and paste password [B] as required in the Faraday section). Save and exit.
 
   ```sh
   $ nano lit.conf
@@ -597,7 +651,7 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   
   # Your password for the UI must be at least 8 characters long
   
-  uipassword=PASSWORD_[B]
+  uipassword=PASSWORD_[E]
   lnd-mode=integrated
   
   # LND settings
@@ -609,9 +663,56 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   lnd.maxpendingchannels=5
   lnd.listen=localhost
   
-  # You may be interested in wumbo channels
+  # Fee settings - default LND base fee = 1000 (mSat), default LND fee rate = 1 (ppm)
+  lnd.bitcoin.basefee=1000
+  lnd.bitcoin.feerate=10
   
-  lnd.protocol.wumbo-channels=1
+  # Minimum channel size (in satoshis, default is 20,000 sats)
+  lnd.minchansize=100000
+  
+  # Accept AMP (multi-paths) payments and wumbo channels
+  lnd.accept-amp=true
+  lnd.protocol.wumbo-channels=true
+  
+  # Save on closing fees
+  ## The target number of blocks in which a cooperative close initiated by a remote peer should be confirmed (default: 10 blocks).
+  lnd.coop-close-target-confs=24
+  
+  #########################
+  # Improve startup speed # (from https://www.lightningnode.info/advanced-tools/lnd.conf by Openoms)
+  #########################
+  # If true, we'll attempt to garbage collect canceled invoices upon start.
+  lnd.gc-canceled-invoices-on-startup=true
+  # If true, we'll delete newly canceled invoices on the fly.
+  lnd.gc-canceled-invoices-on-the-fly=true
+  # Avoid historical graph data sync
+  lnd.ignore-historical-gossip-filters=1
+  # Enable free list syncing for the default bbolt database. This will decrease
+  # start up time, but can result in performance degradation for very large
+  # databases, and also result in higher memory usage. If "free list corruption"
+  # is detected, then this flag may resolve things.
+  lnd.sync-freelist=true
+  # Avoid high startup overhead
+  # If true, will apply a randomized staggering between 0s and 30s when
+  # reconnecting to persistent peers on startup. The first 10 reconnections will be
+  # attempted instantly, regardless of the flag's value
+  lnd.stagger-initial-reconnect=true
+  
+  ########################
+  # Compact the database # (slightly modified from https://www.lightningnode.info/advanced-tools/lnd.conf by Openoms)
+  ########################
+  # Can be used on demand by commenting in/out the two options below: it can take several minutes
+  # [bolt]
+  # Whether the databases used within lnd should automatically be compacted on
+  # every startup (and if the database has the configured minimum age). This is
+  # disabled by default because it requires additional disk space to be available
+  # during the compaction that is freed afterwards. In general compaction leads to
+  # smaller database files.
+  lnd.db.bolt.auto-compact=true
+  # How long ago the last compaction of a database file must be for it to be
+  # considered for auto compaction again. Can be set to 0 to compact on every
+  # startup. (default: 168h)
+  lnd.db.bolt.auto-compact-min-age=168
   
   # [Bitcoin]
   lnd.bitcoin.active=1
@@ -623,13 +724,24 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   lnd.tor.v3=true
   lnd.tor.streamisolation=true
   
-  # Faraday settings
+  #################
+  # Pool settings #
+  #################
+  # This option avoids the creation of channels with nodes with whom you already have a channel (set to 0 if you don't mind)
+  pool.newnodesonly=1
   
+  ####################
+  # Faraday settings #
+  ####################
+  # If connect_bitcoin is set to 1, Faraday can connect to a bitcoin node (with --txindex set) to provide node accounting services
   faraday.connect_bitcoin=1
+  # The Bitcoin node IP is the IP address of the Raspibolt, i.e. an address like 192.168.0.20
+  faraday.bitcoin.host=[Bitcoin node IP]:8332
+  # bitcoin.user provides to Faraday the bicoind RPC username, as specified in our bitcoin.conf
   faraday.bitcoin.user=raspibolt
+  # bitcoin.password provides to Faraday the bitcoind RPC password, as specified in our bitcoin.conf
   faraday.bitcoin.password=PASSWORD_[B]
   ```
-
 
 🔍 *Notice that the options for LND, Faraday, Loop and Pool can be set in this configuration file but you must prefix the software with a dot as we made here. Use samples configuration files shown in github repo of each software for more options*
   

--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -102,9 +102,10 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   # Minimum channel size (in satoshis, default is 20,000 sats)
   minchansize=100000
   
-  # Accept AMP (multi-paths) payments and wumbo channels
+  # Accept AMP (multi-paths) payments, wumbo channels and do not prevent the creation of anchor channel (default value)
   accept-amp=true
   protocol.wumbo-channels=true
+  protocol.no-anchors=false
   
   # Save on closing fees
   ## The target number of blocks in which a cooperative close initiated by a remote peer should be confirmed (default: 10 blocks).
@@ -671,9 +672,10 @@ LiT has its own configuration file. The settings for LND, Pool, Faraday, Loop ca
   # Minimum channel size (in satoshis, default is 20,000 sats)
   lnd.minchansize=100000
   
-  # Accept AMP (multi-paths) payments and wumbo channels
+  # Accept AMP (multi-paths) payments, wumbo channels and do not prevent the creation of anchor channel (default value)
   lnd.accept-amp=true
   lnd.protocol.wumbo-channels=true
+  lnd.protocol.no-anchors=false
   
   # Save on closing fees
   ## The target number of blocks in which a cooperative close initiated by a remote peer should be confirmed (default: 10 blocks).


### PR DESCRIPTION
Summary: the updates aim at:
1. using the latest lnd and litd releases,
2. correcting typos and broken links,
3. adding useful options to the lnd/litd configuration files,
4. replacing outdated commands and examples and warning for outdated videos, and;
5. adding a few safety information for some commands.

The full list of changes and rationales for them:
1. Added warning above most videos: (Warning: the video below is outdated and does not correspond exactly to the commands above)
2. Updated the 'download and install' section with latest release (v0.13.1). Removed bitconner-related lines as not used for the verification process.
3. Updated lnd.conf content 
4. Removed protocol.anchor=true (now by default) (Fixes #748 )
5. Added AMP payments options (did not add keysend as AMP renders keysend obsolete with time)
6. Made minchansize option visible and changed it from default (20,000) to 100,000 sats
7. Made base fee and fee rate settings visible (kept default value)
8. Modified the default value of coop-close-target-confs to save on closing fees
9. Added the startup speed section from https://www.lightningnode.info/advanced-tools/lnd.conf (by Openoms)
10. Removed the 'sudo su - bitcoin' user login at the start of section "Run LND": not needed as we already are with user bitcoin after the lnd.conf section.
11. Removed "and admin.macaroon" when veryfing the TLS certs in folder /mnt/ext/lnd/
12. Added commands to allow safe reboots of the node (line 373)
13. Replaced the np2wkh address creation for funding by a bech32 p2wkh address
14. Replaced the nested segwit full address by the string bc1... (to avid risk of funds being sent to example address)
15. Added 'optional' to the autopilot mention as it is not by default
16. Added amboss.space together with 1ML as amboss despite being newer seems to be more actively developped than 1ml.
17. Default node to demonstrate lncli connect and lncli openchannel is down, replaced by ACINQ which should be a stable long-lasting node and useful for routing.
18. Removed the lncli openchannel command that does not use the optional fee selection --sat_per_byte (leads to needlessly overpaying fees)
19. Replaced deprecated sat_per_byte with preferred sat_per_vbyte in the openchannel command
20. Broken link converter satoshi to USD, fixed
21. Add comment and link to check mempool.space to select appropriate fee
22. In "More commands", added an example on how to send an invoice-less payment to a node using AMP
23. Added sat_per_vbyte option to cloeschannel command
24. Ask for selection of a new passwod [E] for the Lightning Terminal UI password
25. Change LiT password to a new password [E] rather than reusing RPC password [B]
26. Updated lit.conf to reflect changes above and added options for Pool and Faraday