### PR TITLE
anchors option deprecated

### DIFF
--- a/raspibolt_40_lnd.md
+++ b/raspibolt_40_lnd.md
@@ -97,7 +97,7 @@ Now that LND is installed, we need to configure it to work with Bitcoin Core and
   debuglevel=info
   maxpendingchannels=5
   listen=localhost
-  protocol.anchors=true
+  protocol.no-anchors=false
   protocol.wumbo-channels=true
 
   [Bitcoin]


### PR DESCRIPTION
I assume that `protocol.no-anchors=false` is the equivalent to the option `protocol.anchors=true`. 

I changed it because the protocol.anchors attribute is not supported anymore. 

See here [https://github.com/lightningnetwork/lnd/blob/951e2164fdbc77cac604881d689177a179577261/sample-lnd.conf#L1070](https://github.com/lightningnetwork/lnd/blob/951e2164fdbc77cac604881d689177a179577261/sample-lnd.conf#L1070)